### PR TITLE
feature: work on adding better inventory refreshing

### DIFF
--- a/core/src/main/java/org/incendo/interfaces/core/view/SelfUpdatingInterfaceView.java
+++ b/core/src/main/java/org/incendo/interfaces/core/view/SelfUpdatingInterfaceView.java
@@ -1,0 +1,8 @@
+package org.incendo.interfaces.core.view;
+
+/**
+ * Represents an Interface View that does not need to be reopened to be refreshed
+ */
+public interface SelfUpdatingInterfaceView {
+
+}

--- a/examples/example-kotlin/src/main/kotlin/org/incendo/interfaces/example/kotlin/KotlinPlugin.kt
+++ b/examples/example-kotlin/src/main/kotlin/org/incendo/interfaces/example/kotlin/KotlinPlugin.kt
@@ -1,5 +1,6 @@
 package org.incendo.interfaces.example.kotlin
 
+import kotlin.random.Random
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
@@ -16,6 +17,7 @@ import org.incendo.interfaces.kotlin.paper.asElement
 import org.incendo.interfaces.kotlin.paper.buildChestInterface
 import org.incendo.interfaces.kotlin.paper.open
 import org.incendo.interfaces.paper.PaperInterfaceListeners
+import org.incendo.interfaces.paper.transform.PaperTransform
 import org.incendo.interfaces.paper.type.ChestInterface
 
 @Suppress("unused")
@@ -56,11 +58,16 @@ public class KotlinPlugin : JavaPlugin() {
                                 .append(text(event.slot.toString(), NamedTextColor.GOLD)))
                     })
 
+                addTransform(
+                    PaperTransform.chestFill(createItemStack(Material.DIRT, text("")).asElement()))
+
                 withTransform { view ->
                     for (column in 0 until CHEST_COLUMNS) {
                         for (row in 0 until CHEST_ROWS) {
-                            view[column, row] =
-                                createItemStack(LEAVES.random(), text("background")).asElement()
+                            if (Random.nextInt(5) == 3) {
+                                view[column, row] =
+                                    createItemStack(LEAVES.random(), text("background")).asElement()
+                            }
                         }
                     }
                 }
@@ -72,6 +79,7 @@ public class KotlinPlugin : JavaPlugin() {
                     // Create an item stack element with the player's name.
                     val element =
                         createItemStack(Material.PAPER, text(name)).asElement { event, clickView ->
+                            println(1)
                             counterX += 1
                             if (counterX == CHEST_COLUMNS) {
                                 counterX = 0

--- a/paper/src/main/java/org/incendo/interfaces/paper/PaperInterfaceListeners.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/PaperInterfaceListeners.java
@@ -15,6 +15,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.incendo.interfaces.core.UpdatingInterface;
 import org.incendo.interfaces.core.view.InterfaceView;
+import org.incendo.interfaces.core.view.SelfUpdatingInterfaceView;
 import org.incendo.interfaces.paper.element.ItemStackElement;
 import org.incendo.interfaces.paper.view.ChestView;
 import org.incendo.interfaces.paper.view.InventoryView;
@@ -72,12 +73,18 @@ public class PaperInterfaceListeners implements Listener {
             if (view.parent() instanceof UpdatingInterface) {
                 UpdatingInterface updatingInterface = (UpdatingInterface) view.parent();
                 if (updatingInterface.updates()) {
-                    new BukkitRunnable() {
+                    BukkitRunnable runnable = new BukkitRunnable() {
                         @Override
                         public void run() {
                             view.update();
                         }
-                    }.runTaskLater(this.plugin, updatingInterface.updateDelay());
+                    };
+
+                    if (view instanceof SelfUpdatingInterfaceView) {
+                        runnable.runTaskTimer(this.plugin, updatingInterface.updateDelay(), updatingInterface.updateDelay());
+                    } else {
+                        runnable.runTaskLater(this.plugin, updatingInterface.updateDelay());
+                    }
                 }
             }
         }

--- a/paper/src/main/java/org/incendo/interfaces/paper/element/ItemStackElement.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/element/ItemStackElement.java
@@ -6,6 +6,8 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.incendo.interfaces.core.element.Element;
 import org.incendo.interfaces.paper.pane.ChestPane;
 
+import java.util.Objects;
+
 /**
  * Holds an {@link ItemStack} in an element.
  *
@@ -90,6 +92,23 @@ public class ItemStackElement implements Element {
      */
     public @NonNull ClickHandler handler() {
         return this.handler;
+    }
+
+    @Override
+    public final boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ItemStackElement that = (ItemStackElement) o;
+        return this.itemStack.equals(that.itemStack);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(this.itemStack);
     }
 
 }

--- a/paper/src/main/java/org/incendo/interfaces/paper/element/TextElement.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/element/TextElement.java
@@ -4,6 +4,8 @@ import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.incendo.interfaces.core.element.Element;
 
+import java.util.Objects;
+
 /**
  * An element containing a piece of text.
  */
@@ -39,5 +41,21 @@ public class TextElement implements Element {
         return this.text;
     }
 
+    @Override
+    public final boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TextElement that = (TextElement) o;
+        return this.text.equals(that.text);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(this.text);
+    }
 
 }

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/BookInterface.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/BookInterface.java
@@ -21,8 +21,7 @@ import java.util.List;
 public final class BookInterface implements TitledInterface<BookPane, PlayerViewer> {
 
     private final @NonNull List<Transform<BookPane>> transforms;
-    private @NonNull
-    final Component title;
+    private final @NonNull Component title;
 
     /**
      * Constructs {@code BookInterface}.
@@ -126,7 +125,7 @@ public final class BookInterface implements TitledInterface<BookPane, PlayerView
             @NonNull final InterfaceArgument arguments,
             @NonNull final Component title
     ) {
-        final @NonNull BookView view = new BookView(this, (PlayerViewer) viewer, arguments, title);
+        final @NonNull BookView view = new BookView(this, viewer, arguments, title);
 
         view.open();
 


### PR DESCRIPTION
To prevent flashing in inventories we can reuse the same bukkit inventory instance and check what elements actually have to be updated.

Not 100% happy with this yet, this is currently only for the bukkit chest interface but some of this logic could be moved to core