### PR TITLE
Child Views

### DIFF
--- a/.checkstyle/checkstyle-suppressions.xml
+++ b/.checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+    <suppress checks="(?:Javadoc.*)" files=".*[\\/]examples[\\/].*"/>
+</suppressions>

--- a/.checkstyle/checkstyle.xml
+++ b/.checkstyle/checkstyle.xml
@@ -64,6 +64,12 @@
         <property name="fileNamePattern" value="module\-info\.java$"/>
     </module>
 
+    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
+        <property name="optional" value="false"/>
+    </module>
+
     <!-- Checks that a package-info.java file exists for each package.     -->
     <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
     <module name="JavadocPackage"/>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("net.kyori.indra")
     id("net.kyori.indra.publishing") apply false
     id("net.kyori.indra.checkstyle") apply false
+    id("xyz.jpenilla.run-paper") apply false
 
     // Auto-generates project files.
     idea

--- a/core/src/main/java/org/incendo/interfaces/core/Interface.java
+++ b/core/src/main/java/org/incendo/interfaces/core/Interface.java
@@ -56,6 +56,18 @@ public interface Interface<T extends Pane, U extends InterfaceViewer> {
     );
 
     /**
+     * Opens an interface with a parent view.
+     *
+     * @param view      the parent view
+     * @param arguments the interface's arguments
+     * @return the view
+     */
+    @NonNull InterfaceView<T, U> open(
+            @NonNull InterfaceView<?, U> view,
+            @NonNull InterfaceArgument arguments
+    );
+
+    /**
      * An interface that represents an interface builder.
      *
      * @param <T> the pane type

--- a/core/src/main/java/org/incendo/interfaces/core/view/InterfaceView.java
+++ b/core/src/main/java/org/incendo/interfaces/core/view/InterfaceView.java
@@ -18,7 +18,7 @@ public interface InterfaceView<T extends Pane, U extends InterfaceViewer> {
      *
      * @return the interface
      */
-    @NonNull Interface<T, U> parent();
+    @NonNull Interface<T, U> backing();
 
     /**
      * Returns the viewer of this view.
@@ -66,7 +66,7 @@ public interface InterfaceView<T extends Pane, U extends InterfaceViewer> {
      */
     default void update() {
         if (this.viewing()) {
-            this.parent().open(this.viewer(), this.argument());
+            this.backing().open(this.viewer(), this.argument());
         }
     }
 

--- a/core/src/main/java/org/incendo/interfaces/core/view/InterfaceView.java
+++ b/core/src/main/java/org/incendo/interfaces/core/view/InterfaceView.java
@@ -21,6 +21,13 @@ public interface InterfaceView<T extends Pane, U extends InterfaceViewer> {
     @NonNull Interface<T, U> backing();
 
     /**
+     * Returns the argument provided to this view.
+     *
+     * @return the view's argument
+     */
+    @NonNull InterfaceArgument argument();
+
+    /**
      * Returns the viewer of this view.
      * <p>
      * This will always return a value; every view must be constructed
@@ -41,11 +48,11 @@ public interface InterfaceView<T extends Pane, U extends InterfaceViewer> {
     boolean viewing();
 
     /**
-     * Returns the argument provided to this view.
+     * Returns the pane.
      *
-     * @return the view's argument
+     * @return the pane
      */
-    @NonNull InterfaceArgument argument();
+    T pane();
 
     /**
      * Opens the view to the viewer.
@@ -53,13 +60,6 @@ public interface InterfaceView<T extends Pane, U extends InterfaceViewer> {
      * @see #viewer()
      */
     void open();
-
-    /**
-     * Returns the pane.
-     *
-     * @return the pane
-     */
-    T pane();
 
     /**
      * Triggers a manual update.

--- a/examples/example-java/build.gradle.kts
+++ b/examples/example-java/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("xyz.jpenilla.run-paper")
+}
+
+dependencies {
+    implementation(project(":interfaces-core"))
+    implementation(project(":interfaces-paper"))
+
+    compileOnlyApi(libs.paper.api) {
+        exclude(module = "guava")
+        exclude(module = "gson")
+        exclude(module = "snakeyaml")
+        exclude(module = "commons-lang")
+    }
+}
+
+tasks {
+    runServer {
+        minecraftVersion("1.16.5")
+    }
+}

--- a/examples/example-java/src/main/java/org/incendo/interfaces/example/java/ExampleJavaPlugin.java
+++ b/examples/example-java/src/main/java/org/incendo/interfaces/example/java/ExampleJavaPlugin.java
@@ -1,13 +1,11 @@
 package org.incendo.interfaces.example.java;
 
 import org.bukkit.plugin.java.JavaPlugin;
-import org.incendo.interfaces.paper.type.ChestInterface;
-import org.incendo.interfaces.paper.view.ChestView;
 
 /**
  * The example plugin's main class.
  */
-public class ExamplePlugin extends JavaPlugin {
+public class ExampleJavaPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {

--- a/examples/example-java/src/main/resources/plugin.yml
+++ b/examples/example-java/src/main/resources/plugin.yml
@@ -1,0 +1,4 @@
+name: ExampleJavaPlugin
+version: 1.0.0
+main: org.incendo.interfaces.example.java.ExampleJavaPlugin
+api-version: 1.16

--- a/examples/example-kotlin/src/main/java/org.incendo.interfaces.example.java/ExamplePlugin.java
+++ b/examples/example-kotlin/src/main/java/org.incendo.interfaces.example.java/ExamplePlugin.java
@@ -1,0 +1,16 @@
+package org.incendo.interfaces.example.java;
+
+import org.bukkit.plugin.java.JavaPlugin;
+import org.incendo.interfaces.paper.type.ChestInterface;
+import org.incendo.interfaces.paper.view.ChestView;
+
+/**
+ * The example plugin's main class.
+ */
+public class ExamplePlugin extends JavaPlugin {
+
+    @Override
+    public void onEnable() {
+    }
+
+}

--- a/examples/example-kotlin/src/main/kotlin/org/incendo/interfaces/example/kotlin/KotlinPlugin.kt
+++ b/examples/example-kotlin/src/main/kotlin/org/incendo/interfaces/example/kotlin/KotlinPlugin.kt
@@ -17,6 +17,7 @@ import org.incendo.interfaces.kotlin.paper.asElement
 import org.incendo.interfaces.kotlin.paper.buildChestInterface
 import org.incendo.interfaces.kotlin.paper.open
 import org.incendo.interfaces.paper.PaperInterfaceListeners
+import org.incendo.interfaces.paper.pane.ChestPane
 import org.incendo.interfaces.paper.type.ChestInterface
 
 @Suppress("unused")
@@ -71,7 +72,9 @@ public class KotlinPlugin : JavaPlugin() {
 
                     // Create an item stack element with the player's name.
                     val element =
-                        createItemStack(Material.PAPER, text(name)).asElement { event, clickView ->
+                        createItemStack(Material.PAPER, text(name)).asElement<ChestPane> {
+                            event,
+                            clickView ->
                             counterX += 1
                             if (counterX == CHEST_COLUMNS) {
                                 counterX = 0

--- a/examples/example-kotlin/src/main/kotlin/org/incendo/interfaces/example/kotlin/KotlinPlugin.kt
+++ b/examples/example-kotlin/src/main/kotlin/org/incendo/interfaces/example/kotlin/KotlinPlugin.kt
@@ -8,6 +8,7 @@ import org.bukkit.command.Command
 import org.bukkit.command.CommandExecutor
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
+import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.inventory.ItemStack
 import org.bukkit.plugin.java.JavaPlugin
 import org.incendo.interfaces.kotlin.argument
@@ -50,12 +51,11 @@ public class KotlinPlugin : JavaPlugin() {
 
                 updates(true, 5)
                 clickHandler(
-                    canceling { event, _ ->
+                    canceling { event: InventoryClickEvent, _ ->
                         event.whoClicked.sendMessage(
                             text("You clicked ", NamedTextColor.GRAY)
                                 .append(text(event.slot.toString(), NamedTextColor.GOLD)))
                     })
-
                 withTransform { view ->
                     for (column in 0 until CHEST_COLUMNS) {
                         for (row in 0 until CHEST_ROWS) {

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/InterfaceViewExt.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/InterfaceViewExt.kt
@@ -8,7 +8,7 @@ import org.incendo.interfaces.core.view.InterfaceViewer
 
 /** The parent interface. */
 public val <T : Pane, U : InterfaceViewer> InterfaceView<T, U>.parent: Interface<T, U>
-    get() = this.parent()
+    get() = this.backing()
 
 /** The viewer of this view. */
 public val InterfaceView<*, *>.viewer: InterfaceViewer

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/MutableInterfaceBuilder.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/MutableInterfaceBuilder.kt
@@ -2,7 +2,6 @@ package org.incendo.interfaces.kotlin
 
 import org.incendo.interfaces.core.pane.Pane
 import org.incendo.interfaces.paper.element.ClickHandler
-import org.incendo.interfaces.paper.view.PlayerView
 
 public interface MutableInterfaceBuilder<T : Pane> {
 
@@ -14,6 +13,6 @@ public interface MutableInterfaceBuilder<T : Pane> {
      * @return the handler
      */
     public fun canceling(
-        clickHandler: ClickHandler<T> = ClickHandler { _, _ -> }
+            clickHandler: ClickHandler<T> = ClickHandler { _, _ -> }
     ): ClickHandler<T> = ClickHandler.canceling(clickHandler)
 }

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/MutableInterfaceBuilder.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/MutableInterfaceBuilder.kt
@@ -14,6 +14,6 @@ public interface MutableInterfaceBuilder<T : Pane> {
      * @return the handler
      */
     public fun canceling(
-        clickHandler: ClickHandler<T, PlayerView<T>> = ClickHandler { _, _ -> }
-    ): ClickHandler<T, PlayerView<T>> = ClickHandler.canceling(clickHandler)
+        clickHandler: ClickHandler<T> = ClickHandler { _, _ -> }
+    ): ClickHandler<T> = ClickHandler.canceling(clickHandler)
 }

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/MutableInterfaceBuilder.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/MutableInterfaceBuilder.kt
@@ -13,6 +13,6 @@ public interface MutableInterfaceBuilder<T : Pane> {
      * @return the handler
      */
     public fun canceling(
-            clickHandler: ClickHandler<T> = ClickHandler { _, _ -> }
+        clickHandler: ClickHandler<T> = ClickHandler { _, _ -> }
     ): ClickHandler<T> = ClickHandler.canceling(clickHandler)
 }

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/MutableInterfaceBuilder.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/MutableInterfaceBuilder.kt
@@ -2,6 +2,7 @@ package org.incendo.interfaces.kotlin
 
 import org.incendo.interfaces.core.pane.Pane
 import org.incendo.interfaces.paper.element.ClickHandler
+import org.incendo.interfaces.paper.view.PlayerView
 
 public interface MutableInterfaceBuilder<T : Pane> {
 
@@ -13,6 +14,6 @@ public interface MutableInterfaceBuilder<T : Pane> {
      * @return the handler
      */
     public fun canceling(
-        clickHandler: ClickHandler<T> = ClickHandler { _, _ -> }
-    ): ClickHandler<T> = ClickHandler.canceling(clickHandler)
+        clickHandler: ClickHandler<T, PlayerView<T>> = ClickHandler { _, _ -> }
+    ): ClickHandler<T, PlayerView<T>> = ClickHandler.canceling(clickHandler)
 }

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/InventoryViewExt.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/InventoryViewExt.kt
@@ -1,12 +1,12 @@
 package org.incendo.interfaces.kotlin.paper
 
 import org.bukkit.inventory.Inventory
-import org.incendo.interfaces.paper.view.InventoryView
+import org.incendo.interfaces.paper.view.PlayerView
 
 /**
  * Returns the inventory.
  *
  * @return the inventory
  */
-public val InventoryView<*>.inventory: Inventory
-    get() = this.inventory()
+public val PlayerView<*>.inventory: Inventory
+    get() = this.inventory

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestInterfaceBuilder.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestInterfaceBuilder.kt
@@ -9,7 +9,6 @@ import org.incendo.interfaces.paper.PlayerViewer
 import org.incendo.interfaces.paper.element.ClickHandler
 import org.incendo.interfaces.paper.pane.ChestPane
 import org.incendo.interfaces.paper.type.ChestInterface
-import org.incendo.interfaces.paper.view.ChestView
 import org.incendo.interfaces.paper.view.PlayerView
 
 @Suppress("unused")
@@ -82,7 +81,8 @@ public class MutableChestInterfaceBuilder : MutableInterfaceBuilder<ChestPane> {
         transform: (ChestPane, InterfaceView<ChestPane, PlayerViewer>) -> ChestPane
     ): Unit = mutate {
         internalBuilder.addTransform(
-            transform as (ChestPane, InterfaceView<ChestPane, *>) -> ChestPane)
+            transform as (ChestPane, InterfaceView<ChestPane, *>) -> ChestPane
+        )
     }
 
     /**

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestInterfaceBuilder.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestInterfaceBuilder.kt
@@ -49,9 +49,10 @@ public class MutableChestInterfaceBuilder : MutableInterfaceBuilder<ChestPane> {
      *
      * @param handler click handler
      */
-    public fun clickHandler(
-        handler: (InventoryClickEvent, PlayerView<ChestPane>) -> Unit
-    ): Unit = mutate { internalBuilder.clickHandler(handler) }
+    public fun clickHandler(handler: (InventoryClickEvent, PlayerView<ChestPane>) -> Unit): Unit =
+        mutate {
+        internalBuilder.clickHandler(handler)
+    }
 
     /**
      * Sets the click handler
@@ -81,8 +82,7 @@ public class MutableChestInterfaceBuilder : MutableInterfaceBuilder<ChestPane> {
         transform: (ChestPane, InterfaceView<ChestPane, PlayerViewer>) -> ChestPane
     ): Unit = mutate {
         internalBuilder.addTransform(
-            transform as (ChestPane, InterfaceView<ChestPane, *>) -> ChestPane
-        )
+            transform as (ChestPane, InterfaceView<ChestPane, *>) -> ChestPane)
     }
 
     /**

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestInterfaceBuilder.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestInterfaceBuilder.kt
@@ -9,6 +9,7 @@ import org.incendo.interfaces.paper.PlayerViewer
 import org.incendo.interfaces.paper.element.ClickHandler
 import org.incendo.interfaces.paper.pane.ChestPane
 import org.incendo.interfaces.paper.type.ChestInterface
+import org.incendo.interfaces.paper.view.ChestView
 import org.incendo.interfaces.paper.view.PlayerView
 
 @Suppress("unused")
@@ -28,7 +29,7 @@ public class MutableChestInterfaceBuilder : MutableInterfaceBuilder<ChestPane> {
         set(value) = mutate { internalBuilder.title(value) }
 
     /** The click handler of the interface. */
-    public var clickHandler: ClickHandler<ChestPane>
+    public var clickHandler: ClickHandler<ChestPane, ChestView>
         get() = internalBuilder.clickHandler()
         set(value) = mutate { internalBuilder.clickHandler(value) }
     // </editor-fold>
@@ -58,7 +59,7 @@ public class MutableChestInterfaceBuilder : MutableInterfaceBuilder<ChestPane> {
      *
      * @param handler click handler
      */
-    public fun clickHandler(handler: ClickHandler<ChestPane>): Unit = mutate {
+    public fun clickHandler(handler: ClickHandler<ChestPane, ChestView>): Unit = mutate {
         internalBuilder.clickHandler(handler)
     }
 

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestInterfaceBuilder.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestInterfaceBuilder.kt
@@ -9,7 +9,7 @@ import org.incendo.interfaces.paper.PlayerViewer
 import org.incendo.interfaces.paper.element.ClickHandler
 import org.incendo.interfaces.paper.pane.ChestPane
 import org.incendo.interfaces.paper.type.ChestInterface
-import org.incendo.interfaces.paper.view.InventoryView
+import org.incendo.interfaces.paper.view.PlayerView
 
 @Suppress("unused")
 public class MutableChestInterfaceBuilder : MutableInterfaceBuilder<ChestPane> {
@@ -50,7 +50,7 @@ public class MutableChestInterfaceBuilder : MutableInterfaceBuilder<ChestPane> {
      * @param handler click handler
      */
     public fun clickHandler(
-        handler: (InventoryClickEvent, InventoryView<ChestPane>) -> Unit
+        handler: (InventoryClickEvent, PlayerView<ChestPane>) -> Unit
     ): Unit = mutate { internalBuilder.clickHandler(handler) }
 
     /**

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestInterfaceBuilder.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestInterfaceBuilder.kt
@@ -29,7 +29,7 @@ public class MutableChestInterfaceBuilder : MutableInterfaceBuilder<ChestPane> {
         set(value) = mutate { internalBuilder.title(value) }
 
     /** The click handler of the interface. */
-    public var clickHandler: ClickHandler<ChestPane, ChestView>
+    public var clickHandler: ClickHandler<ChestPane>
         get() = internalBuilder.clickHandler()
         set(value) = mutate { internalBuilder.clickHandler(value) }
     // </editor-fold>
@@ -59,7 +59,7 @@ public class MutableChestInterfaceBuilder : MutableInterfaceBuilder<ChestPane> {
      *
      * @param handler click handler
      */
-    public fun clickHandler(handler: ClickHandler<ChestPane, ChestView>): Unit = mutate {
+    public fun clickHandler(handler: ClickHandler<ChestPane>): Unit = mutate {
         internalBuilder.clickHandler(handler)
     }
 

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestPaneView.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/MutableChestPaneView.kt
@@ -21,7 +21,8 @@ public class MutableChestPaneView(
      * @param y the y coordinate
      * @return the element
      */
-    public operator fun get(x: Int, y: Int): ItemStackElement = internalPane.element(x, y)
+    public operator fun get(x: Int, y: Int): ItemStackElement<ChestPane> =
+        internalPane.element(x, y)
 
     /**
      * Sets an element at the given position.
@@ -30,7 +31,7 @@ public class MutableChestPaneView(
      * @param y the y coordinate
      * @param element the element
      */
-    public operator fun set(x: Int, y: Int, element: ItemStackElement): Unit = mutate {
+    public operator fun set(x: Int, y: Int, element: ItemStackElement<ChestPane>): Unit = mutate {
         element(element, x, y)
     }
 

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/PaperExt.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/PaperExt.kt
@@ -66,5 +66,5 @@ public fun Player.asViewer(): PlayerViewer = PlayerViewer.of(this)
  * @param handler optional click handler
  * @return element instance
  */
-public fun ItemStack.asElement(handler: ClickHandler<*, *>? = null): ItemStackElement =
+public fun ItemStack.asElement(handler: ClickHandler<*>? = null): ItemStackElement =
     if (handler == null) ItemStackElement.of(this) else ItemStackElement.of(this, handler)

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/PaperExt.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/PaperExt.kt
@@ -66,5 +66,5 @@ public fun Player.asViewer(): PlayerViewer = PlayerViewer.of(this)
  * @param handler optional click handler
  * @return element instance
  */
-public fun ItemStack.asElement(handler: ClickHandler<*>? = null): ItemStackElement =
+public fun ItemStack.asElement(handler: ClickHandler<*, *>? = null): ItemStackElement =
     if (handler == null) ItemStackElement.of(this) else ItemStackElement.of(this, handler)

--- a/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/PaperExt.kt
+++ b/kotlin/src/main/kotlin/org/incendo/interfaces/kotlin/paper/PaperExt.kt
@@ -66,5 +66,5 @@ public fun Player.asViewer(): PlayerViewer = PlayerViewer.of(this)
  * @param handler optional click handler
  * @return element instance
  */
-public fun ItemStack.asElement(handler: ClickHandler<*>? = null): ItemStackElement =
+public fun <T : Pane> ItemStack.asElement(handler: ClickHandler<T>? = null): ItemStackElement<T> =
     if (handler == null) ItemStackElement.of(this) else ItemStackElement.of(this, handler)

--- a/paper/src/main/java/org/incendo/interfaces/paper/PaperInterfaceListeners.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/PaperInterfaceListeners.java
@@ -129,7 +129,7 @@ public class PaperInterfaceListeners implements Listener {
                 int y = slot / 9;
 
                 final @NonNull ItemStackElement element = chestView.pane().element(x, y);
-                element.handler().accept(event, chestView);
+                element.clickHandler().accept(event, (PlayerView) chestView);
             }
         }
     }

--- a/paper/src/main/java/org/incendo/interfaces/paper/PaperInterfaceListeners.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/PaperInterfaceListeners.java
@@ -69,8 +69,8 @@ public class PaperInterfaceListeners implements Listener {
             InventoryView<?> view = (InventoryView<?>) holder;
             this.openViews.add(view);
 
-            if (view.parent() instanceof UpdatingInterface) {
-                UpdatingInterface updatingInterface = (UpdatingInterface) view.parent();
+            if (view.backing() instanceof UpdatingInterface) {
+                UpdatingInterface updatingInterface = (UpdatingInterface) view.backing();
                 if (updatingInterface.updates()) {
                     new BukkitRunnable() {
                         @Override
@@ -120,7 +120,7 @@ public class PaperInterfaceListeners implements Listener {
         if (holder instanceof ChestView) {
             ChestView chestView = (ChestView) holder;
             // Handle parent interface click event
-            chestView.parent().clickHandler().accept(event, chestView);
+            chestView.backing().clickHandler().accept(event, chestView);
 
             // Handle element click event
             if (event.getSlotType() == InventoryType.SlotType.CONTAINER) {

--- a/paper/src/main/java/org/incendo/interfaces/paper/PaperInterfaceListeners.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/PaperInterfaceListeners.java
@@ -17,7 +17,7 @@ import org.incendo.interfaces.core.UpdatingInterface;
 import org.incendo.interfaces.core.view.InterfaceView;
 import org.incendo.interfaces.paper.element.ItemStackElement;
 import org.incendo.interfaces.paper.view.ChestView;
-import org.incendo.interfaces.paper.view.InventoryView;
+import org.incendo.interfaces.paper.view.PlayerView;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -65,8 +65,8 @@ public class PaperInterfaceListeners implements Listener {
             return;
         }
 
-        if (holder instanceof InventoryView) {
-            InventoryView<?> view = (InventoryView<?>) holder;
+        if (holder instanceof PlayerView) {
+            PlayerView<?> view = (PlayerView<?>) holder;
             this.openViews.add(view);
 
             if (view.backing() instanceof UpdatingInterface) {
@@ -97,8 +97,8 @@ public class PaperInterfaceListeners implements Listener {
             return;
         }
 
-        if (holder instanceof InventoryView) {
-            this.openViews.remove((InventoryView) holder);
+        if (holder instanceof PlayerView) {
+            this.openViews.remove((PlayerView) holder);
         }
     }
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/PlayerViewerImpl.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/PlayerViewerImpl.java
@@ -25,7 +25,7 @@ final class PlayerViewerImpl implements PlayerViewer {
      * @param chestView the chest view
      */
     private void openChestView(final @NonNull ChestView chestView) {
-        this.player.openInventory(chestView.inventory());
+        this.player.openInventory(chestView.getInventory());
     }
 
     /**

--- a/paper/src/main/java/org/incendo/interfaces/paper/element/ClickHandler.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/element/ClickHandler.java
@@ -3,7 +3,7 @@ package org.incendo.interfaces.paper.element;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.incendo.interfaces.core.pane.Pane;
-import org.incendo.interfaces.paper.view.InventoryView;
+import org.incendo.interfaces.paper.view.PlayerView;
 
 import java.util.function.BiConsumer;
 
@@ -12,7 +12,7 @@ import java.util.function.BiConsumer;
  *
  * @param <T> the pane type
  */
-public interface ClickHandler<T extends Pane> extends BiConsumer<InventoryClickEvent, InventoryView<T>> {
+public interface ClickHandler<T extends Pane> extends BiConsumer<InventoryClickEvent, PlayerView<T>> {
 
     /**
      * Returns a {@code ClickHandler} that cancels the event and then calls

--- a/paper/src/main/java/org/incendo/interfaces/paper/element/ClickHandler.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/element/ClickHandler.java
@@ -11,12 +11,11 @@ import java.util.function.BiConsumer;
  * A function that handles a click event on an interface.
  *
  * @param <T> the pane type
- * @param <U> the view type
  */
-public interface ClickHandler<T extends Pane, U extends PlayerView<T>> extends BiConsumer<InventoryClickEvent, U> {
+public interface ClickHandler<T extends Pane> extends BiConsumer<InventoryClickEvent, PlayerView<T>> {
 
-    static @NonNull <T extends Pane, U extends PlayerView<T>> ClickHandler<T, U> of(BiConsumer<InventoryClickEvent, U> consumer) {
-        return (ClickHandler<T, U>) consumer;
+    static @NonNull <T extends Pane> ClickHandler<T> of(BiConsumer<InventoryClickEvent, PlayerView<T>> consumer) {
+        return (ClickHandler<T>) consumer;
     }
 
     /**
@@ -27,7 +26,7 @@ public interface ClickHandler<T extends Pane, U extends PlayerView<T>> extends B
      * @param <T>          the pane type
      * @return the handler
      */
-    static @NonNull <T extends Pane, U extends PlayerView<T>> ClickHandler<T, U> canceling(final @NonNull ClickHandler<T, U> clickHandler) {
+    static @NonNull <T extends Pane> ClickHandler<T> canceling(final @NonNull ClickHandler<T> clickHandler) {
         return (event, view) -> {
             event.setCancelled(true);
 
@@ -39,10 +38,9 @@ public interface ClickHandler<T extends Pane, U extends PlayerView<T>> extends B
      * Returns a {@code ClickHandler} that cancels the event.
      *
      * @param <T> the pane type
-     * @param <U> the view type
      * @return the handler
      */
-    static @NonNull <T extends Pane, U extends PlayerView<T>> ClickHandler<T, U> cancel() {
+    static @NonNull <T extends Pane> ClickHandler<T> cancel() {
         return (event, view) -> event.setCancelled(true);
     }
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/element/ClickHandler.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/element/ClickHandler.java
@@ -14,10 +14,6 @@ import java.util.function.BiConsumer;
  */
 public interface ClickHandler<T extends Pane> extends BiConsumer<InventoryClickEvent, PlayerView<T>> {
 
-    static @NonNull <T extends Pane> ClickHandler<T> of(BiConsumer<InventoryClickEvent, PlayerView<T>> consumer) {
-        return (ClickHandler<T>) consumer;
-    }
-
     /**
      * Returns a {@code ClickHandler} that cancels the event and then calls
      * the given click handler.

--- a/paper/src/main/java/org/incendo/interfaces/paper/element/ClickHandler.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/element/ClickHandler.java
@@ -11,18 +11,23 @@ import java.util.function.BiConsumer;
  * A function that handles a click event on an interface.
  *
  * @param <T> the pane type
+ * @param <U> the view type
  */
-public interface ClickHandler<T extends Pane> extends BiConsumer<InventoryClickEvent, PlayerView<T>> {
+public interface ClickHandler<T extends Pane, U extends PlayerView<T>> extends BiConsumer<InventoryClickEvent, U> {
+
+    static @NonNull <T extends Pane, U extends PlayerView<T>> ClickHandler<T, U> of(BiConsumer<InventoryClickEvent, U> consumer) {
+        return (ClickHandler<T, U>) consumer;
+    }
 
     /**
      * Returns a {@code ClickHandler} that cancels the event and then calls
      * the given click handler.
      *
      * @param clickHandler the handler
-     * @param <T>          pane type
+     * @param <T>          the pane type
      * @return the handler
      */
-    static @NonNull <T extends Pane> ClickHandler<T> canceling(final @NonNull ClickHandler<T> clickHandler) {
+    static @NonNull <T extends Pane, U extends PlayerView<T>> ClickHandler<T, U> canceling(final @NonNull ClickHandler<T, U> clickHandler) {
         return (event, view) -> {
             event.setCancelled(true);
 
@@ -33,10 +38,11 @@ public interface ClickHandler<T extends Pane> extends BiConsumer<InventoryClickE
     /**
      * Returns a {@code ClickHandler} that cancels the event.
      *
-     * @param <T> pane type
+     * @param <T> the pane type
+     * @param <U> the view type
      * @return the handler
      */
-    static @NonNull <T extends Pane> ClickHandler<T> cancel() {
+    static @NonNull <T extends Pane, U extends PlayerView<T>> ClickHandler<T, U> cancel() {
         return (event, view) -> event.setCancelled(true);
     }
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/element/ItemStackElement.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/element/ItemStackElement.java
@@ -4,17 +4,19 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.incendo.interfaces.core.element.Element;
+import org.incendo.interfaces.core.pane.Pane;
 import org.incendo.interfaces.paper.pane.ChestPane;
+import org.incendo.interfaces.paper.type.Clickable;
 
 /**
  * Holds an {@link ItemStack} in an element.
  *
  * @see ChestPane
  */
-public class ItemStackElement implements Element {
+public class ItemStackElement<T extends Pane> implements Element, Clickable<T> {
 
     private final @NonNull ItemStack itemStack;
-    private final @NonNull ClickHandler handler;
+    private final @NonNull ClickHandler<T> handler;
 
     /**
      * Constructs {@code ItemStackElement}.
@@ -35,7 +37,7 @@ public class ItemStackElement implements Element {
      */
     public ItemStackElement(
             final @NonNull ItemStack itemStack,
-            final @NonNull ClickHandler clickHandler
+            final @NonNull ClickHandler<T> clickHandler
     ) {
         this.itemStack = itemStack;
         this.handler = clickHandler;
@@ -46,8 +48,8 @@ public class ItemStackElement implements Element {
      *
      * @return an empty {@code ItemStackElement}.
      */
-    public static @NonNull ItemStackElement empty() {
-        return new ItemStackElement(new ItemStack(Material.AIR));
+    public static <T extends Pane> @NonNull ItemStackElement<T> empty() {
+        return new ItemStackElement<T>(new ItemStack(Material.AIR));
     }
 
     /**
@@ -56,8 +58,8 @@ public class ItemStackElement implements Element {
      * @param itemStack the ItemStack
      * @return the element
      */
-    public static @NonNull ItemStackElement of(final @NonNull ItemStack itemStack) {
-        return new ItemStackElement(itemStack);
+    public static <T extends Pane> @NonNull ItemStackElement<T> of(final @NonNull ItemStack itemStack) {
+        return new ItemStackElement<T>(itemStack);
     }
 
     /**
@@ -67,11 +69,11 @@ public class ItemStackElement implements Element {
      * @param handler   the handler
      * @return the element
      */
-    public static @NonNull ItemStackElement of(
+    public static <T extends Pane> @NonNull ItemStackElement<T> of(
             final @NonNull ItemStack itemStack,
-            final @NonNull ClickHandler handler
+            final @NonNull ClickHandler<T> handler
     ) {
-        return new ItemStackElement(itemStack, handler);
+        return new ItemStackElement<T>(itemStack, handler);
     }
 
     /**
@@ -88,7 +90,7 @@ public class ItemStackElement implements Element {
      *
      * @return the click handler
      */
-    public @NonNull ClickHandler handler() {
+    public @NonNull ClickHandler<T> clickHandler() {
         return this.handler;
     }
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/element/ItemStackElement.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/element/ItemStackElement.java
@@ -11,6 +11,7 @@ import org.incendo.interfaces.paper.type.Clickable;
 /**
  * Holds an {@link ItemStack} in an element.
  *
+ * @param <T> the pane type
  * @see ChestPane
  */
 public class ItemStackElement<T extends Pane> implements Element, Clickable<T> {
@@ -46,20 +47,22 @@ public class ItemStackElement<T extends Pane> implements Element, Clickable<T> {
     /**
      * Returns an empty {@code ItemStackElement}.
      *
+     * @param <T> the pane type
      * @return an empty {@code ItemStackElement}.
      */
     public static <T extends Pane> @NonNull ItemStackElement<T> empty() {
-        return new ItemStackElement<T>(new ItemStack(Material.AIR));
+        return new ItemStackElement<>(new ItemStack(Material.AIR));
     }
 
     /**
      * Returns an {@code ItemStackElement} with the provided ItemStack.
      *
      * @param itemStack the ItemStack
+     * @param <T> the pane type
      * @return the element
      */
     public static <T extends Pane> @NonNull ItemStackElement<T> of(final @NonNull ItemStack itemStack) {
-        return new ItemStackElement<T>(itemStack);
+        return new ItemStackElement<>(itemStack);
     }
 
     /**
@@ -67,13 +70,14 @@ public class ItemStackElement<T extends Pane> implements Element, Clickable<T> {
      *
      * @param itemStack the ItemStack
      * @param handler   the handler
+     * @param <T> the pane type
      * @return the element
      */
     public static <T extends Pane> @NonNull ItemStackElement<T> of(
             final @NonNull ItemStack itemStack,
             final @NonNull ClickHandler<T> handler
     ) {
-        return new ItemStackElement<T>(itemStack, handler);
+        return new ItemStackElement<>(itemStack, handler);
     }
 
     /**

--- a/paper/src/main/java/org/incendo/interfaces/paper/pane/ChestPane.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/pane/ChestPane.java
@@ -16,7 +16,7 @@ public class ChestPane implements Pane {
 
     public static final int MINECRAFT_CHEST_WIDTH = 9;
 
-    private final @NonNull List<List<ItemStackElement>> elements;
+    private final @NonNull List<List<ItemStackElement<ChestPane>>> elements;
 
     private final int rows;
 
@@ -32,7 +32,7 @@ public class ChestPane implements Pane {
 
         // Fill the arrays with empty elements.
         for (int i = 0; i < MINECRAFT_CHEST_WIDTH; i++) {
-            final @NonNull List<ItemStackElement> deepElements = new ArrayList<>();
+            final @NonNull List<ItemStackElement<ChestPane>> deepElements = new ArrayList<>();
 
             for (int j = 0; j < this.rows; j++) {
                 deepElements.add(j, ItemStackElement.empty());
@@ -48,7 +48,7 @@ public class ChestPane implements Pane {
      * @param rows     amount of rows
      * @param elements the elements
      */
-    public ChestPane(final int rows, final @NonNull List<List<ItemStackElement>> elements) {
+    public ChestPane(final int rows, final @NonNull List<List<ItemStackElement<ChestPane>>> elements) {
         this.rows = rows;
         this.elements = elements;
     }
@@ -58,7 +58,7 @@ public class ChestPane implements Pane {
      *
      * @return the elements
      */
-    public @NonNull List<List<ItemStackElement>> chestElements() {
+    public @NonNull List<List<ItemStackElement<ChestPane>>> chestElements() {
         return this.elements;
     }
 
@@ -100,10 +100,10 @@ public class ChestPane implements Pane {
      * @param y       the y coordinate
      * @return a new {@code ChestPane}
      */
-    public @NonNull ChestPane element(final @NonNull ItemStackElement element, final int x, final int y) {
-        final @NonNull List<List<ItemStackElement>> newElements = new ArrayList<>();
+    public @NonNull ChestPane element(final @NonNull ItemStackElement<ChestPane> element, final int x, final int y) {
+        final @NonNull List<List<ItemStackElement<ChestPane>>> newElements = new ArrayList<>();
 
-        for (final @NonNull List<ItemStackElement> elements : this.elements) {
+        for (final @NonNull List<ItemStackElement<ChestPane>> elements : this.elements) {
             newElements.add(new ArrayList<>(elements));
         }
 
@@ -119,7 +119,7 @@ public class ChestPane implements Pane {
      * @param y the y coordinate
      * @return the element
      */
-    public @NonNull ItemStackElement element(final int x, final int y) {
+    public @NonNull ItemStackElement<ChestPane> element(final int x, final int y) {
         return this.elements.get(x).get(y);
     }
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/BookInterface.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/BookInterface.java
@@ -4,13 +4,16 @@ import java.util.Collections;
 
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.incendo.interfaces.core.Interface;
 import org.incendo.interfaces.core.arguments.HashMapInterfaceArgument;
 import org.incendo.interfaces.core.arguments.InterfaceArgument;
 import org.incendo.interfaces.core.transform.Transform;
+import org.incendo.interfaces.core.view.InterfaceView;
 import org.incendo.interfaces.paper.PlayerViewer;
 import org.incendo.interfaces.paper.pane.BookPane;
 import org.incendo.interfaces.paper.view.BookView;
+import org.incendo.interfaces.paper.view.PlayerView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -126,11 +129,19 @@ public final class BookInterface implements TitledInterface<BookPane, PlayerView
             @NonNull final InterfaceArgument arguments,
             @NonNull final Component title
     ) {
-        final @NonNull BookView view = new BookView(this, (PlayerViewer) viewer, arguments, title);
+        final @NonNull BookView view = new BookView(this, viewer, arguments, title);
 
         view.open();
 
         return view;
+    }
+
+    @Override
+    public @NonNull BookView open(
+            @NonNull final InterfaceView<?, PlayerViewer> view,
+            @NonNull final InterfaceArgument arguments
+    ) {
+        return this.open(view.viewer(), arguments);
     }
 
     /**

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/BookInterface.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/BookInterface.java
@@ -1,10 +1,7 @@
 package org.incendo.interfaces.paper.type;
 
-import java.util.Collections;
-
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.incendo.interfaces.core.Interface;
 import org.incendo.interfaces.core.arguments.HashMapInterfaceArgument;
 import org.incendo.interfaces.core.arguments.InterfaceArgument;
@@ -13,9 +10,9 @@ import org.incendo.interfaces.core.view.InterfaceView;
 import org.incendo.interfaces.paper.PlayerViewer;
 import org.incendo.interfaces.paper.pane.BookPane;
 import org.incendo.interfaces.paper.view.BookView;
-import org.incendo.interfaces.paper.view.PlayerView;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/ChestInterface.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/ChestInterface.java
@@ -29,7 +29,7 @@ public final class ChestInterface implements
     private final @NonNull Component title;
     private final boolean updates;
     private final int updateDelay;
-    private final @NonNull ClickHandler<ChestPane, ChestView> clickHandler;
+    private final @NonNull ClickHandler<ChestPane> clickHandler;
 
     /**
      * Constructs {@code ChestInterface}.
@@ -47,7 +47,7 @@ public final class ChestInterface implements
             final @NonNull List<Transform<ChestPane>> transforms,
             final boolean updates,
             final int updateDelay,
-            final @NonNull ClickHandler<ChestPane, ChestView> clickHandler
+            final @NonNull ClickHandler<ChestPane> clickHandler
     ) {
         this.title = title;
         this.transformationList = transforms;
@@ -80,7 +80,7 @@ public final class ChestInterface implements
      *
      * @return the click handler
      */
-    public @NonNull ClickHandler<ChestPane, ChestView> clickHandler() {
+    public @NonNull ClickHandler<ChestPane> clickHandler() {
         return this.clickHandler;
     }
 
@@ -204,7 +204,7 @@ public final class ChestInterface implements
         /**
          * The top click handler.
          */
-        private final @NonNull ClickHandler<ChestPane, ChestView> clickHandler;
+        private final @NonNull ClickHandler<ChestPane> clickHandler;
 
         /**
          * Constructs {@code Builder}.
@@ -224,7 +224,7 @@ public final class ChestInterface implements
                 @NonNull final Component title,
                 final boolean updates,
                 final int updateDelay,
-                @NonNull final ClickHandler<ChestPane, ChestView> clickHandler
+                @NonNull final ClickHandler<ChestPane> clickHandler
         ) {
             this.transformsList = Collections.unmodifiableList(transformsList);
             this.rows = rows;
@@ -312,7 +312,7 @@ public final class ChestInterface implements
          *
          * @return click handler
          */
-        public @NonNull ClickHandler<ChestPane, ChestView> clickHandler() {
+        public @NonNull ClickHandler<ChestPane> clickHandler() {
             return this.clickHandler;
         }
 
@@ -322,7 +322,7 @@ public final class ChestInterface implements
          * @param handler the handler
          * @return new builder instance
          */
-        public @NonNull Builder clickHandler(final @NonNull ClickHandler<ChestPane, ChestView> handler) {
+        public @NonNull Builder clickHandler(final @NonNull ClickHandler<ChestPane> handler) {
             return new Builder(
                     this.transformsList,
                     this.rows,

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/ChestInterface.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/ChestInterface.java
@@ -22,7 +22,7 @@ import java.util.List;
 public final class ChestInterface implements
         TitledInterface<ChestPane, PlayerViewer>,
         UpdatingInterface,
-        ClickableInterface {
+        Clickable {
 
     private final int rows;
     private final @NonNull List<Transform<ChestPane>> transformationList;

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/ChestInterface.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/ChestInterface.java
@@ -7,10 +7,14 @@ import org.incendo.interfaces.core.UpdatingInterface;
 import org.incendo.interfaces.core.arguments.HashMapInterfaceArgument;
 import org.incendo.interfaces.core.arguments.InterfaceArgument;
 import org.incendo.interfaces.core.transform.Transform;
+import org.incendo.interfaces.core.view.InterfaceView;
 import org.incendo.interfaces.paper.PlayerViewer;
 import org.incendo.interfaces.paper.element.ClickHandler;
+import org.incendo.interfaces.paper.pane.BookPane;
 import org.incendo.interfaces.paper.pane.ChestPane;
+import org.incendo.interfaces.paper.view.BookView;
 import org.incendo.interfaces.paper.view.ChestView;
+import org.incendo.interfaces.paper.view.PlayerView;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -134,6 +138,18 @@ public final class ChestInterface implements
             final @NonNull Component title
     ) {
         final @NonNull ChestView view = new ChestView(this, viewer, arguments, title);
+
+        view.open();
+
+        return view;
+    }
+
+    @Override
+    public @NonNull ChestView open(
+            @NonNull final InterfaceView<?, PlayerViewer> parent,
+            @NonNull final InterfaceArgument arguments
+    ) {
+        final @NonNull ChestView view = new ChestView((PlayerView<?>) parent, this, parent.viewer(), arguments, title);
 
         view.open();
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/ChestInterface.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/ChestInterface.java
@@ -10,9 +10,7 @@ import org.incendo.interfaces.core.transform.Transform;
 import org.incendo.interfaces.core.view.InterfaceView;
 import org.incendo.interfaces.paper.PlayerViewer;
 import org.incendo.interfaces.paper.element.ClickHandler;
-import org.incendo.interfaces.paper.pane.BookPane;
 import org.incendo.interfaces.paper.pane.ChestPane;
-import org.incendo.interfaces.paper.view.BookView;
 import org.incendo.interfaces.paper.view.ChestView;
 import org.incendo.interfaces.paper.view.PlayerView;
 
@@ -149,7 +147,7 @@ public final class ChestInterface implements
             @NonNull final InterfaceView<?, PlayerViewer> parent,
             @NonNull final InterfaceArgument arguments
     ) {
-        final @NonNull ChestView view = new ChestView((PlayerView<?>) parent, this, parent.viewer(), arguments, title);
+        final @NonNull ChestView view = new ChestView((PlayerView<?>) parent, this, parent.viewer(), arguments, this.title);
 
         view.open();
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/ChestInterface.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/ChestInterface.java
@@ -29,7 +29,7 @@ public final class ChestInterface implements
     private final @NonNull Component title;
     private final boolean updates;
     private final int updateDelay;
-    private final @NonNull ClickHandler<ChestPane> clickHandler;
+    private final @NonNull ClickHandler<ChestPane, ChestView> clickHandler;
 
     /**
      * Constructs {@code ChestInterface}.
@@ -47,7 +47,7 @@ public final class ChestInterface implements
             final @NonNull List<Transform<ChestPane>> transforms,
             final boolean updates,
             final int updateDelay,
-            final @NonNull ClickHandler<ChestPane> clickHandler
+            final @NonNull ClickHandler<ChestPane, ChestView> clickHandler
     ) {
         this.title = title;
         this.transformationList = transforms;
@@ -80,7 +80,7 @@ public final class ChestInterface implements
      *
      * @return the click handler
      */
-    public @NonNull ClickHandler<ChestPane> clickHandler() {
+    public @NonNull ClickHandler<ChestPane, ChestView> clickHandler() {
         return this.clickHandler;
     }
 
@@ -204,7 +204,7 @@ public final class ChestInterface implements
         /**
          * The top click handler.
          */
-        private final @NonNull ClickHandler<ChestPane> clickHandler;
+        private final @NonNull ClickHandler<ChestPane, ChestView> clickHandler;
 
         /**
          * Constructs {@code Builder}.
@@ -224,7 +224,7 @@ public final class ChestInterface implements
                 @NonNull final Component title,
                 final boolean updates,
                 final int updateDelay,
-                @NonNull final ClickHandler<ChestPane> clickHandler
+                @NonNull final ClickHandler<ChestPane, ChestView> clickHandler
         ) {
             this.transformsList = Collections.unmodifiableList(transformsList);
             this.rows = rows;
@@ -312,7 +312,7 @@ public final class ChestInterface implements
          *
          * @return click handler
          */
-        public @NonNull ClickHandler<ChestPane> clickHandler() {
+        public @NonNull ClickHandler<ChestPane, ChestView> clickHandler() {
             return this.clickHandler;
         }
 
@@ -322,7 +322,7 @@ public final class ChestInterface implements
          * @param handler the handler
          * @return new builder instance
          */
-        public @NonNull Builder clickHandler(final @NonNull ClickHandler<ChestPane> handler) {
+        public @NonNull Builder clickHandler(final @NonNull ClickHandler<ChestPane, ChestView> handler) {
             return new Builder(
                     this.transformsList,
                     this.rows,

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/Clickable.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/Clickable.java
@@ -8,6 +8,8 @@ import org.incendo.interfaces.paper.element.ClickHandler;
  * Represents a clickable interface.
  * <p>
  * {@code clickHandler} will be called whenever the viewer clicks on the interface.
+ *
+ * @param <T> the pane type
  */
 public interface Clickable<T extends Pane> {
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/Clickable.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/Clickable.java
@@ -8,7 +8,7 @@ import org.incendo.interfaces.paper.element.ClickHandler;
  * <p>
  * {@code clickHandler} will be called whenever the viewer clicks on the interface.
  */
-public interface ClickableInterface {
+public interface Clickable {
 
     /**
      * Returns the top click handler.

--- a/paper/src/main/java/org/incendo/interfaces/paper/type/Clickable.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/type/Clickable.java
@@ -1,6 +1,7 @@
 package org.incendo.interfaces.paper.type;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.incendo.interfaces.core.pane.Pane;
 import org.incendo.interfaces.paper.element.ClickHandler;
 
 /**
@@ -8,13 +9,13 @@ import org.incendo.interfaces.paper.element.ClickHandler;
  * <p>
  * {@code clickHandler} will be called whenever the viewer clicks on the interface.
  */
-public interface Clickable {
+public interface Clickable<T extends Pane> {
 
     /**
      * Returns the top click handler.
      *
      * @return the top click handler
      */
-    @NonNull ClickHandler clickHandler();
+    @NonNull ClickHandler<T> clickHandler();
 
 }

--- a/paper/src/main/java/org/incendo/interfaces/paper/utils/PaperUtils.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/utils/PaperUtils.java
@@ -1,0 +1,29 @@
+package org.incendo.interfaces.paper.utils;
+
+/**
+ * A collection of utility methods.
+ */
+public class PaperUtils {
+
+    /**
+     * Converts a Bukkit slot index to an x/y position.
+     *
+     * @param slot the slot
+     * @return the x/y position
+     */
+    public static int[] slotToGrid(final int slot) {
+        return new int[]{slot % 9, slot / 9};
+    }
+
+    /**
+     * Converts the x/y position to a Bukkit slot index.
+     *
+     * @param x the x position
+     * @param y the y position
+     * @return the slot
+     */
+    public static int gridToSlot(final int x, final int y) {
+        return y * 9 + x;
+    }
+
+}

--- a/paper/src/main/java/org/incendo/interfaces/paper/utils/PaperUtils.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/utils/PaperUtils.java
@@ -3,7 +3,7 @@ package org.incendo.interfaces.paper.utils;
 /**
  * A collection of utility methods.
  */
-public class PaperUtils {
+public final class PaperUtils {
 
     /**
      * Converts a Bukkit slot index to an x/y position.
@@ -26,4 +26,5 @@ public class PaperUtils {
         return y * 9 + x;
     }
 
+    private PaperUtils() {}
 }

--- a/paper/src/main/java/org/incendo/interfaces/paper/utils/package-info.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/utils/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utilities for the Paper interfaces implementation.
+ */
+package org.incendo.interfaces.paper.utils;

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/BookView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/BookView.java
@@ -77,7 +77,7 @@ public final class BookView implements InterfaceView<BookPane, PlayerViewer> {
      * @return the parent
      */
     @Override
-    public @NonNull BookInterface parent() {
+    public @NonNull BookInterface backing() {
         return this.parent;
     }
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
@@ -99,9 +99,9 @@ public final class ChestView implements
 
     @Override
     public @NonNull PlayerView<?> back() {
-        if (hasParent()) {
-            parent.open();
-            return parent;
+        if (this.hasParent()) {
+            this.parent.open();
+            return this.parent;
         }
 
         throw new NullPointerException("The view has no parent");

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
@@ -165,11 +165,11 @@ public final class ChestView implements
                 this.title
         );
 
-        final @NonNull List<List<ItemStackElement>> elements = this.pane.chestElements();
+        final @NonNull List<List<ItemStackElement<ChestPane>>> elements = this.pane.chestElements();
 
         for (int x = 0; x < ChestPane.MINECRAFT_CHEST_WIDTH; x++) {
             for (int y = 0; y < this.backing.rows(); y++) {
-                final @NonNull ItemStackElement element = elements.get(x).get(y);
+                final @NonNull ItemStackElement<ChestPane> element = elements.get(x).get(y);
 
                 inventory.setItem(PaperUtils.gridToSlot(x, y), element.itemStack());
             }

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
@@ -5,7 +5,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.incendo.interfaces.core.Interface;
+import org.incendo.interfaces.core.arguments.HashMapInterfaceArgument;
 import org.incendo.interfaces.core.arguments.InterfaceArgument;
+import org.incendo.interfaces.core.view.InterfaceView;
 import org.incendo.interfaces.paper.PlayerViewer;
 import org.incendo.interfaces.paper.element.ItemStackElement;
 import org.incendo.interfaces.paper.pane.ChestPane;
@@ -77,6 +80,31 @@ public final class ChestView implements
         this.pane = pane;
 
         this.inventory = this.createInventory();
+    }
+
+    /**
+     * Opens a child interface.
+     *
+     * @param backing the backing interface
+     * @param <T> the type of view
+     * @return the view
+     */
+    public @NonNull <T extends PlayerView<?>> T openChild(final @NonNull Interface<?, PlayerViewer> backing) {
+        final InterfaceView<?, PlayerViewer> view = backing.open(this.viewer, HashMapInterfaceArgument.empty());
+
+        view.open();
+
+        return (T) view;
+    }
+
+    @Override
+    public @NonNull PlayerView<?> back() {
+        if (hasParent()) {
+            parent.open();
+            return parent;
+        }
+
+        throw new NullPointerException("The view has no parent");
     }
 
     @Override

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
@@ -9,6 +9,7 @@ import org.incendo.interfaces.paper.PlayerViewer;
 import org.incendo.interfaces.paper.element.ItemStackElement;
 import org.incendo.interfaces.paper.pane.ChestPane;
 import org.incendo.interfaces.paper.type.ChestInterface;
+import org.incendo.interfaces.paper.utils.PaperUtils;
 
 import java.util.List;
 
@@ -55,27 +56,6 @@ public final class ChestView implements InventoryView<ChestPane> {
     }
 
     /**
-     * Converts a Bukkit slot index to an x/y position.
-     *
-     * @param slot the slot
-     * @return the x/y position
-     */
-    public static int[] slotToGrid(final int slot) {
-        return new int[]{slot % 9, slot / 9};
-    }
-
-    /**
-     * Converts the x/y position to a Bukkit slot index.
-     *
-     * @param x the x position
-     * @param y the y position
-     * @return the slot
-     */
-    public static int gridToSlot(final int x, final int y) {
-        return y * 9 + x;
-    }
-
-    /**
      * Creates the Bukkit inventory.
      *
      * @return the inventory
@@ -93,7 +73,7 @@ public final class ChestView implements InventoryView<ChestPane> {
             for (int y = 0; y < this.backing.rows(); y++) {
                 final @NonNull ItemStackElement element = elements.get(x).get(y);
 
-                inventory.setItem(gridToSlot(x, y), element.itemStack());
+                inventory.setItem(PaperUtils.gridToSlot(x, y), element.itemStack());
             }
         }
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.incendo.interfaces.core.arguments.InterfaceArgument;
 import org.incendo.interfaces.paper.PlayerViewer;
 import org.incendo.interfaces.paper.element.ItemStackElement;
@@ -16,10 +17,11 @@ import java.util.List;
 /**
  * The view of a chest.
  */
-public final class ChestView implements InventoryView<ChestPane> {
+public final class ChestView implements PlayerView<ChestPane> {
 
     private final @NonNull PlayerViewer viewer;
     private final @NonNull ChestInterface backing;
+    private final @Nullable PlayerView<?> parent;
     private final @NonNull Inventory inventory;
     private final @NonNull InterfaceArgument argument;
     private final @NonNull ChestPane pane;
@@ -39,6 +41,26 @@ public final class ChestView implements InventoryView<ChestPane> {
             final @NonNull InterfaceArgument argument,
             final @NonNull Component title
     ) {
+        this(null, backing, viewer, argument, title);
+    }
+
+    /**
+     * Constructs {@code ChestView}.
+     *
+     * @param parent   the parent view
+     * @param backing  the backing interface
+     * @param viewer   the viewer
+     * @param argument the interface argument
+     * @param title    the title
+     */
+    public ChestView(
+            final @Nullable PlayerView<?> parent,
+            final @NonNull ChestInterface backing,
+            final @NonNull PlayerViewer viewer,
+            final @NonNull InterfaceArgument argument,
+            final @NonNull Component title
+    ) {
+        this.parent = parent;
         this.viewer = viewer;
         this.backing = backing;
         this.argument = argument;
@@ -53,6 +75,60 @@ public final class ChestView implements InventoryView<ChestPane> {
         this.pane = pane;
 
         this.inventory = this.createInventory();
+    }
+
+    /**
+     * Returns true if this view has a parent, false if not.
+     *
+     * @return true if this view has a parent, false if not
+     */
+    public boolean hasParent() {
+        return this.parent != null;
+    }
+
+    /**
+     * Returns the parent view, if any.
+     *
+     * @return the parent view, if any
+     */
+    public @Nullable PlayerView<?> parent() {
+        return this.parent;
+    }
+
+
+    @Override
+    public @NonNull ChestInterface backing() {
+        return this.backing;
+    }
+
+    @Override
+    public @NonNull PlayerViewer viewer() {
+        return this.viewer;
+    }
+
+    @Override
+    public boolean viewing() {
+        return this.inventory.getViewers().contains(this.viewer.player());
+    }
+
+    @Override
+    public @NonNull InterfaceArgument argument() {
+        return this.argument;
+    }
+
+    @Override
+    public void open() {
+        this.viewer.open(this);
+    }
+
+    @Override
+    public @NonNull ChestPane pane() {
+        return this.pane;
+    }
+
+    @Override
+    public @NonNull Inventory getInventory() {
+        return this.inventory;
     }
 
     /**
@@ -78,83 +154,6 @@ public final class ChestView implements InventoryView<ChestPane> {
         }
 
         return inventory;
-    }
-
-    /**
-     * Returns the parent.
-     *
-     * @return the parent
-     */
-    @Override
-    public @NonNull ChestInterface backing() {
-        return this.backing;
-    }
-
-    /**
-     * Returns the viewer.
-     *
-     * @return the viewer
-     */
-    @Override
-    public @NonNull PlayerViewer viewer() {
-        return this.viewer;
-    }
-
-    /**
-     * Returns true if {@link #viewer()} is viewing this view, false if not.
-     *
-     * @return true if {@link #viewer()} is viewing this view, false if not
-     */
-    @Override
-    public boolean viewing() {
-        return this.inventory.getViewers().contains(this.viewer.player());
-    }
-
-    /**
-     * Returns the argument provided to this view.
-     *
-     * @return the argument
-     */
-    @Override
-    public @NonNull InterfaceArgument argument() {
-        return this.argument;
-    }
-
-    /**
-     * Opens this view to the viewer.
-     */
-    @Override
-    public void open() {
-        this.viewer.open(this);
-    }
-
-    /**
-     * Returns this view's pane.
-     *
-     * @return the view's pane
-     */
-    @Override
-    public @NonNull ChestPane pane() {
-        return this.pane;
-    }
-
-    /**
-     * Returns the inventory of this view.
-     *
-     * @return the inventory
-     */
-    public @NonNull Inventory getInventory() {
-        return this.inventory;
-    }
-
-    /**
-     * Returns the inventory of this view.
-     *
-     * @return the inventory
-     */
-    @Override
-    public @NonNull Inventory inventory() {
-        return this.inventory;
     }
 
 }

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
@@ -90,7 +90,20 @@ public final class ChestView implements
      * @return the view
      */
     public @NonNull <T extends PlayerView<?>> T openChild(final @NonNull Interface<?, PlayerViewer> backing) {
-        final InterfaceView<?, PlayerViewer> view = backing.open(this.viewer, HashMapInterfaceArgument.empty());
+        return this.openChild(backing, HashMapInterfaceArgument.empty());
+    }
+
+
+    /**
+     * Opens a child interface.
+     *
+     * @param backing the backing interface
+     * @param <T> the type of view
+     * @return the view
+     */
+    public @NonNull <T extends PlayerView<?>> T openChild(final @NonNull Interface<?, PlayerViewer> backing,
+                                                          final @NonNull InterfaceArgument argument) {
+        final InterfaceView<?, PlayerViewer> view = backing.open(this, argument);
 
         view.open();
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
@@ -13,39 +13,39 @@ import org.incendo.interfaces.paper.type.ChestInterface;
 import java.util.List;
 
 /**
- * The view of a Bukkit inventory-based interface.
+ * The view of a chest.
  */
 public final class ChestView implements InventoryView<ChestPane> {
 
     private final @NonNull PlayerViewer viewer;
-    private final @NonNull ChestInterface parent;
+    private final @NonNull ChestInterface backing;
     private final @NonNull Inventory inventory;
     private final @NonNull InterfaceArgument argument;
     private final @NonNull ChestPane pane;
     private final @NonNull Component title;
 
     /**
-     * Constructs {@code InventoryInterfaceView}.
+     * Constructs {@code ChestView}.
      *
+     * @param backing  the backing interface
      * @param viewer   the viewer
-     * @param parent   the parent interface
      * @param argument the interface argument
      * @param title    the title
      */
     public ChestView(
-            final @NonNull ChestInterface parent,
+            final @NonNull ChestInterface backing,
             final @NonNull PlayerViewer viewer,
             final @NonNull InterfaceArgument argument,
             final @NonNull Component title
     ) {
         this.viewer = viewer;
-        this.parent = parent;
+        this.backing = backing;
         this.argument = argument;
         this.title = title;
 
-        @NonNull ChestPane pane = new ChestPane(parent.rows());
+        @NonNull ChestPane pane = new ChestPane(this.backing.rows());
 
-        for (final var transform : this.parent.transformations()) {
+        for (final var transform : this.backing.transformations()) {
             pane = transform.apply(pane, this);
         }
 
@@ -83,14 +83,14 @@ public final class ChestView implements InventoryView<ChestPane> {
     private @NonNull Inventory createInventory() {
         final @NonNull Inventory inventory = Bukkit.createInventory(
                 this,
-                this.parent.rows() * 9,
+                this.backing.rows() * 9,
                 this.title
         );
 
         final @NonNull List<List<ItemStackElement>> elements = this.pane.chestElements();
 
         for (int x = 0; x < ChestPane.MINECRAFT_CHEST_WIDTH; x++) {
-            for (int y = 0; y < this.parent.rows(); y++) {
+            for (int y = 0; y < this.backing.rows(); y++) {
                 final @NonNull ItemStackElement element = elements.get(x).get(y);
 
                 inventory.setItem(gridToSlot(x, y), element.itemStack());
@@ -106,8 +106,8 @@ public final class ChestView implements InventoryView<ChestPane> {
      * @return the parent
      */
     @Override
-    public @NonNull ChestInterface parent() {
-        return this.parent;
+    public @NonNull ChestInterface backing() {
+        return this.backing;
     }
 
     /**

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
@@ -86,7 +86,7 @@ public final class ChestView implements
      * Opens a child interface.
      *
      * @param backing the backing interface
-     * @param <T> the type of view
+     * @param <T>     the type of view
      * @return the view
      */
     public @NonNull <T extends PlayerView<?>> T openChild(final @NonNull Interface<?, PlayerViewer> backing) {
@@ -97,12 +97,15 @@ public final class ChestView implements
     /**
      * Opens a child interface.
      *
-     * @param backing the backing interface
-     * @param <T> the type of view
+     * @param backing  the backing interface
+     * @param argument the argument
+     * @param <T>      the type of view
      * @return the view
      */
-    public @NonNull <T extends PlayerView<?>> T openChild(final @NonNull Interface<?, PlayerViewer> backing,
-                                                          final @NonNull InterfaceArgument argument) {
+    public @NonNull <T extends PlayerView<?>> T openChild(
+            final @NonNull Interface<?, PlayerViewer> backing,
+            final @NonNull InterfaceArgument argument
+    ) {
         final InterfaceView<?, PlayerViewer> view = backing.open(this, argument);
 
         view.open();

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChestView.java
@@ -17,7 +17,9 @@ import java.util.List;
 /**
  * The view of a chest.
  */
-public final class ChestView implements PlayerView<ChestPane> {
+public final class ChestView implements
+        PlayerView<ChestPane>,
+        ChildView {
 
     private final @NonNull PlayerViewer viewer;
     private final @NonNull ChestInterface backing;
@@ -77,20 +79,12 @@ public final class ChestView implements PlayerView<ChestPane> {
         this.inventory = this.createInventory();
     }
 
-    /**
-     * Returns true if this view has a parent, false if not.
-     *
-     * @return true if this view has a parent, false if not
-     */
+    @Override
     public boolean hasParent() {
         return this.parent != null;
     }
 
-    /**
-     * Returns the parent view, if any.
-     *
-     * @return the parent view, if any
-     */
+    @Override
     public @Nullable PlayerView<?> parent() {
         return this.parent;
     }

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChildView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChildView.java
@@ -1,0 +1,25 @@
+package org.incendo.interfaces.paper.view;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Represents a view which can hold a parent.
+ */
+public interface ChildView {
+
+    /**
+     * Returns true if this view has a parent, false if not.
+     *
+     * @return true if this view has a parent, false if not
+     */
+    boolean hasParent();
+
+    /**
+     * Returns the parent view, if any.
+     *
+     * @return the parent view, if any
+     */
+    @Nullable PlayerView<?> parent();
+
+}

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/ChildView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/ChildView.java
@@ -22,4 +22,14 @@ public interface ChildView {
      */
     @Nullable PlayerView<?> parent();
 
+    /**
+     * Returns to the parent view.
+     *
+     * @return the parent view
+     * @throws NullPointerException if there is no parent view
+     * @see #hasParent()
+     * @see #parent()
+     */
+    @NonNull PlayerView<?> back();
+
 }

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/PlayerView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/PlayerView.java
@@ -1,8 +1,6 @@
 package org.incendo.interfaces.paper.view;
 
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.incendo.interfaces.core.pane.Pane;
 import org.incendo.interfaces.core.view.InterfaceView;
 import org.incendo.interfaces.paper.PlayerViewer;

--- a/paper/src/main/java/org/incendo/interfaces/paper/view/PlayerView.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/view/PlayerView.java
@@ -12,14 +12,5 @@ import org.incendo.interfaces.paper.PlayerViewer;
  *
  * @param <T> the pane type
  */
-public interface InventoryView<T extends Pane> extends InterfaceView<T, PlayerViewer>,
-        InventoryHolder {
-
-    /**
-     * Returns the inventory.
-     *
-     * @return the inventory
-     */
-    @NonNull Inventory inventory();
-
-}
+public interface PlayerView<T extends Pane> extends InterfaceView<T, PlayerViewer>,
+        InventoryHolder {}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,8 @@ fun interfacesProjects(vararg names: String) {
 }
 
 // Add the example modules.
+include("examples/example-java")
+project(":examples/example-java").name = "example-java"
 include("examples/example-kotlin")
 project(":examples/example-kotlin").name = "example-kotlin"
 


### PR DESCRIPTION
This PR introduces the concept of child views to interfaces.

**Changes**
- Added `ChildView`, implemented on `ChestView` and `BookView`
- Renamed `InventoryView` to `PlayerView`

I made this change because all I originally wanted InventoryView to be was a quick way to type out `InterfaceView<T, PlayerView>`. Some Paper interface types won't hold an Inventory but may still hold a PlayerViewer, so I think the interface is more useful this way.

- Renamed `ClickableInterface` to `Clickable` and implement `Clickable` on `ItemStackElement`
- Gave `ItemStackElement` the pane type as a generic parameter.
- Some other stuff I probably forgot.
