### PR TITLE
fix: Don't allow/handle elements outside the bounds of a ChestPane

### DIFF
--- a/paper/src/main/java/org/incendo/interfaces/paper/PaperInterfaceListeners.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/PaperInterfaceListeners.java
@@ -407,19 +407,20 @@ public class PaperInterfaceListeners implements Listener {
         );
 
         ChestView chestView = (ChestView) holder;
-        // Handle parent interface click event
-        chestView.backing().clickHandler().accept(context);
 
         // Handle element click event
         if (event.getSlotType() == InventoryType.SlotType.CONTAINER) {
             int slot = event.getSlot();
             int x = slot % 9;
             int y = slot / 9;
+            ChestPane pane = chestView.pane();
 
-            chestView.pane()
-                    .element(x, y)
-                    .clickHandler()
-                    .accept(context);
+            if (y < pane.rows()) {
+                // Handle parent interface click event
+                chestView.backing().clickHandler().accept(context);
+
+                pane.element(x, y).clickHandler().accept(context);
+            }
         }
     }
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/pane/ChestPane.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/pane/ChestPane.java
@@ -102,7 +102,7 @@ public final class ChestPane implements GridPane<ChestPane, ItemStackElement<Che
 
     @Override
     public @NonNull ItemStackElement<ChestPane> element(final int x, final int y) {
-        if (y >= this.rows || x >= 8) {
+        if (y >= this.rows || x > 8) {
             throw new IllegalArgumentException("Cannot access element outside of the bounds of this chest pane.");
         }
 

--- a/paper/src/main/java/org/incendo/interfaces/paper/pane/ChestPane.java
+++ b/paper/src/main/java/org/incendo/interfaces/paper/pane/ChestPane.java
@@ -102,6 +102,10 @@ public final class ChestPane implements GridPane<ChestPane, ItemStackElement<Che
 
     @Override
     public @NonNull ItemStackElement<ChestPane> element(final int x, final int y) {
+        if (y >= this.rows || x >= 8) {
+            throw new IllegalArgumentException("Cannot access element outside of the bounds of this chest pane.");
+        }
+
         return this.elements.get(Vector2.at(x, y));
     }
 


### PR DESCRIPTION
* Moves all chest click event handling inside a method to ensure that clicks outside of a chest pane aren't handled by the chest pane.
* Throws an exception if an element that would be null is attempted to be accessed from a chest pane.

This PR fixes #51.